### PR TITLE
Remove list notation from the weighted podAffinityTerms

### DIFF
--- a/sg-helm/templates/data-statefulset.yaml
+++ b/sg-helm/templates/data-statefulset.yaml
@@ -54,7 +54,7 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1
             podAffinityTerm:
-            - topologyKey: "failure-domain.beta.kubernetes.io/zone"
+              topologyKey: "failure-domain.beta.kubernetes.io/zone"
               labelSelector:
                 matchLabels:
                   component: {{ template "fullname" . }}

--- a/sg-helm/templates/kibana-deployment.yaml
+++ b/sg-helm/templates/kibana-deployment.yaml
@@ -51,7 +51,7 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1
             podAffinityTerm:
-            - topologyKey: "kubernetes.io/hostname"
+              topologyKey: "kubernetes.io/hostname"
               labelSelector:
                 matchLabels:
                   component: {{ template "fullname" . }}
@@ -85,8 +85,8 @@ spec:
             - |
                 #!/usr/bin/env bash -e
                 until kubectl get secrets {{ template "fullname" . }}-passwd-secret; do
-                  echo 'Wait for {{ template "fullname" . }}-passwd-secret'; 
-                  sleep 10 ; 
+                  echo 'Wait for {{ template "fullname" . }}-passwd-secret';
+                  sleep 10 ;
                 done
 
                 echo "OK, {{ template "fullname" . }}-passwd-secret exists now"

--- a/sg-helm/templates/master-statefulset.yaml
+++ b/sg-helm/templates/master-statefulset.yaml
@@ -54,7 +54,7 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1
             podAffinityTerm:
-            - topologyKey: "kubernetes.io/hostname"
+              topologyKey: "kubernetes.io/hostname"
               labelSelector:
                 matchLabels:
                   component: {{ template "fullname" . }}


### PR DESCRIPTION
I found that the 'hard' pod affinity mode wouldn't currently work due to a flaw in the yaml. 

Removes the offending characters for the affected deployment/statefulset definitions. 